### PR TITLE
build: install executables while libiotjs dynamically linked

### DIFF
--- a/cmake/iotjs.cmake
+++ b/cmake/iotjs.cmake
@@ -501,7 +501,7 @@ if(NOT BUILD_LIB_ONLY)
             LIBRARY DESTINATION "${INSTALL_PREFIX}/lib"
             PUBLIC_HEADER DESTINATION "${INSTALL_PREFIX}/include/shadow-node")
   else()
-    install(TARGETS ${TARGET_LIB_IOTJS}
+    install(TARGETS ${TARGET_IOTJS} ${TARGET_LIB_IOTJS}
             RUNTIME DESTINATION "${INSTALL_PREFIX}/bin"
             LIBRARY DESTINATION "${INSTALL_PREFIX}/lib"
             PUBLIC_HEADER DESTINATION "${INSTALL_PREFIX}/include/shadow-node")


### PR DESCRIPTION
executable `iotjs` is not installed on building dynamically linked libiotjs.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
