### PR TITLE
promise: function `promise.then` need to be binded

### DIFF
--- a/src/js/promise.js
+++ b/src/js/promise.js
@@ -104,14 +104,13 @@ function resolve(self, newValue) {
       newValue &&
       (typeof newValue === 'object' || typeof newValue === 'function')
     ) {
-      var then = newValue.then;
       if (newValue instanceof Promise) {
         self._state = STATE_NEXT;
         self._value = newValue;
         finale(self);
         return;
-      } else if (typeof then === 'function') {
-        doResolve(then, self);
+      } else if (typeof newValue.then === 'function') {
+        doResolve(newValue.then.bind(newValue), self);
         return;
       }
     }

--- a/test/run_pass/test_iotjs_promise_then_bind.js
+++ b/test/run_pass/test_iotjs_promise_then_bind.js
@@ -1,0 +1,11 @@
+var assert = require('assert');
+
+class TestObj {
+  constructor() {}
+  then() {
+    assert (this === obj)
+  }
+}
+
+var obj = new TestObj();
+Promise.resolve().then(() => obj);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->
The `newValue.then` should bind itself.
Benchmark:

  | 1 | 2 | 3 | 4 | 5 | AVG
-- | -- | -- | -- | -- | -- | --
resolve-empty-array : before | 28,337 | 20,586 | 28,921 | 24,328 | 24,328 | 25,300
resolve-empty-array: after | 28,521 | 23,573 | 24,739 | 23,207 | 25,225 | 25,053
resolve-statically: before | 27,890 | 26,767 | 26,627 | 26,576 | 26,783 | 26,928.6
resolve-statically: after | 29,911 | 25,449 | 21,390 | 26,315 | 32,903 | 27,193.6
then: before | 34,278 | 24,873 | 28,511 | 24,134 | 25,575 | 27,474.2
then: after | 31,375 | 23,472 | 26,477 | 25,962 | 25,893 | 26,635.8


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
