### PR TITLE
jerry: Fixed 'jerry_get_object_keys' API function.

### DIFF
--- a/deps/jerry/jerry-core/api/jerry.c
+++ b/deps/jerry/jerry-core/api/jerry.c
@@ -2499,7 +2499,8 @@ jerry_get_object_keys (const jerry_value_t obj_val) /**< object value */
     return jerry_throw (ecma_raise_type_error (ECMA_ERR_MSG (wrong_args_msg_p)));
   }
 
-  return ecma_builtin_helper_object_get_properties (ecma_get_object_from_value (obj_value), true);
+  return ecma_builtin_helper_object_get_properties (ecma_get_object_from_value (obj_value),
+                                                    ECMA_LIST_ENUMERABLE);
 } /* jerry_get_object_keys */
 
 /**

--- a/deps/jerry/tests/unit-core/test-api.c
+++ b/deps/jerry/tests/unit-core/test-api.c
@@ -942,6 +942,7 @@ main (void)
   res = jerry_get_object_keys (global_obj_val);
   TEST_ASSERT (!jerry_value_has_error_flag (res));
   TEST_ASSERT (jerry_value_is_array (res));
+  TEST_ASSERT (jerry_get_array_length (res) == 16);
   jerry_release_value (res);
 
   /* Test: jerry_value_to_primitive */


### PR DESCRIPTION
'jerry_get_object_keys' always gave back an empty array.

Picked from https://github.com/pando-project/jerryscript/pulls/2807

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
