### PR TITLE
process: use uv's exception if starting an invalid signal handler

### DIFF
--- a/src/js/iotjs.js
+++ b/src/js/iotjs.js
@@ -522,10 +522,6 @@
       if (!isSignal(type) || signalWraps[type] !== undefined) {
         return;
       }
-      if (type === 'SIGKILL' || type === 'SIGSTOP') {
-        // see sigaction(2), SIGKILL/SIGSTOP are not supported, just skip it.
-        return;
-      }
       var Signal = Module.require('signal');
       var wrap = new Signal();
       wrap.onsignal = process.emit.bind(process, type, type);

--- a/test/run_pass/test_signal_handler_fail.js
+++ b/test/run_pass/test_signal_handler_fail.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var assert = require('assert');
+function shouldNotHandleSignal(type) {
+  assert.throws(() => {
+    process.on(type, () => false);
+  }, {
+    name: 'Error',
+    message: 'uv_signal_start EINVAL(invalid argument)'
+  }, `should throw uv_signal_start(${type}) invalid args`);
+}
+
+shouldNotHandleSignal('SIGKILL');
+shouldNotHandleSignal('SIGSTOP');

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -128,6 +128,7 @@
     { "name": "test_pwm_async.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_pwm_sync.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_shebang.js" },
+    { "name": "test_signal_handler_fail.js" },
     { "name": "test_signal_simple.js" },
     { "name": "test_spi.js", "skip": ["linux"], "reason": "Differend env on Linux desktop/travis/rpi" },
     { "name": "test_spi_buffer.js", "skip": ["all"], "reason": "need to setup test environment" },


### PR DESCRIPTION
This keeps consistent with Node.js' behavior, it uses uv's exception instead of ignoring for this case.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
