### PR TITLE
stream: use empty function if no callback with `write()`

### DIFF
--- a/src/js/stream_writable.js
+++ b/src/js/stream_writable.js
@@ -20,7 +20,7 @@ var util = require('util');
 var Stream = stream.Stream;
 var defaultHighWaterMark = 128;
 
-function nop() {}
+function noop() {}
 
 function WriteReq(chunk, encoding, callback) {
   this.chunk = chunk;
@@ -99,7 +99,7 @@ Writable.prototype.write = function(chunk, encoding, callback) {
   }
 
   if (typeof callback !== 'function')
-    callback = nop;
+    callback = noop;
 
   var state = this._writableState;
 

--- a/src/js/stream_writable.js
+++ b/src/js/stream_writable.js
@@ -20,6 +20,8 @@ var util = require('util');
 var Stream = stream.Stream;
 var defaultHighWaterMark = 128;
 
+function nop() {}
+
 function WriteReq(chunk, encoding, callback) {
   this.chunk = chunk;
   this.encoding = encoding;
@@ -95,6 +97,9 @@ Writable.prototype.write = function(chunk, encoding, callback) {
     callback = encoding;
     encoding = null;
   }
+
+  if (typeof callback !== 'function')
+    callback = nop;
 
   var state = this._writableState;
 

--- a/test/run_pass/test_stream.js
+++ b/test/run_pass/test_stream.js
@@ -15,8 +15,9 @@
 'use strict';
 
 var Readable = require('stream').Readable;
+var Writable = require('stream').Writable;
 var assert = require('assert');
-
+var common = require('../common');
 
 var readable1 = new Readable();
 var d = '';
@@ -152,6 +153,14 @@ assert.throws(function() {
   readable4.push(null);
 }, Error);
 
+// writable
+var writable1 = new Writable();
+writable1._write = common.mustCall(function(data, encoding, cb) {
+  assert.strictEqual(`${data}`, 'foobar');
+  assert.strictEqual(typeof cb, 'function');
+});
+writable1._readyToWrite();
+writable1.write('foobar');
 
 process.on('exit', function() {
   assert.strictEqual(readable2 instanceof Readable, true);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

Add this check https://github.com/nodejs/node/blob/master/lib/_stream_writable.js#L299-L300 at ShadowNode, to reproduce the problem, try the following script:

```js
require('fs').createWriteStream('./test').write('foobar')
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
