### PR TITLE
Revert "jerry: escape slash in JSON.stringify() (#340)"

### DIFF
--- a/deps/jerry/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/deps/jerry/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -1174,7 +1174,7 @@ ecma_builtin_json_quote (ecma_string_t *string_p) /**< string that should be quo
   {
     lit_utf8_byte_t c = *str_p++;
 
-    if (c == LIT_CHAR_BACKSLASH || c == LIT_CHAR_SLASH || c == LIT_CHAR_DOUBLE_QUOTE)
+    if (c == LIT_CHAR_BACKSLASH || c == LIT_CHAR_DOUBLE_QUOTE)
     {
       n_bytes += 2;
     }
@@ -1221,7 +1221,7 @@ ecma_builtin_json_quote (ecma_string_t *string_p) /**< string that should be quo
   {
     lit_utf8_byte_t c = *str_p++;
 
-    if (c == LIT_CHAR_BACKSLASH || c == LIT_CHAR_SLASH ||c == LIT_CHAR_DOUBLE_QUOTE)
+    if (c == LIT_CHAR_BACKSLASH || c == LIT_CHAR_DOUBLE_QUOTE)
     {
       *buf++ = LIT_CHAR_BACKSLASH;
       *buf++ = c;

--- a/test/run_pass/test_iotjs_json.js
+++ b/test/run_pass/test_iotjs_json.js
@@ -17,7 +17,7 @@
 var assert = require('assert');
 
 var jsonObj = { foo: 'http://www.slash.escape' };
-var jsonString = '{\"foo\":\"http:\\/\\/www.slash.escape\"}';
+var jsonString = '{\"foo\":\"http://www.slash.escape\"}';
 var jsonStringify = JSON.stringify(jsonObj);
 
 assert(jsonStringify === jsonString);


### PR DESCRIPTION
This reverts commit 2deca2ee61c6b2a987438ae53d3046254c54d522.

According to [RFC7159](https://tools.ietf.org/html/rfc7159#section-7), all Unicode characters may be placed within the quotation marks, except for the characters that must be escaped: quotation mark, reverse solidus, and the control characters. Any characters may be escaped, but it should be kept as minimal and clear.

With the consensus of above,  characters except for quotation mark, reverse solidus, and the control characters should not be escaped in JSON.stringify.

Fixes: #556 
Refs: #340 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
