### PR TITLE
os: add method `tmpdir()`

### DIFF
--- a/docs/api/OS.md
+++ b/docs/api/OS.md
@@ -43,7 +43,7 @@ The properties available on the assigned network address object include:
 * `scopeid` {Number} The numeric IPv6 scope ID (only specified when family is IPv6)
 * `cidr` {String} The assigned IPv4 or IPv6 address with the routing prefix in CIDR notation. If the netmask is invalid, this property is set to null
 
-```js
+```
 {
   lo: [
     {
@@ -110,3 +110,9 @@ of the current process is used.
 
 The `priority` input must be an integer between `-20` (high priority) and `19`
 (low priority).
+
+## os.tmpdir()
+
+* Returns: {string}
+
+The `os.tmpdir()` method returns a string specifying the operating system's default directory for temporary files.

--- a/src/js/os.js
+++ b/src/js/os.js
@@ -88,3 +88,18 @@ Object.defineProperty(exports, 'EOL', {
     return '\n';
   }
 });
+
+function isStringEndsWith(str, search) {
+  var len = str.length;
+  return str.substring(len - search.length, len) === search;
+}
+
+exports.tmpdir = function tmpdir() {
+  var path = process.env.TMPDIR ||
+             process.env.TMP ||
+             process.env.TEMP || '/tmp';
+  if (path.length > 1 && isStringEndsWith(path, '/'))
+    path = path.slice(0, -1);
+
+  return path;
+};

--- a/test/run_pass/test_os.js
+++ b/test/run_pass/test_os.js
@@ -35,3 +35,21 @@ var expected = [
 ];
 
 assert.deepStrictEqual(actual, expected);
+
+// test for tmpdir
+process.env.TMPDIR = '/tmpdir';
+process.env.TMP = '/tmp';
+process.env.TEMP = '/temp';
+assert.strictEqual(os.tmpdir(), '/tmpdir');
+process.env.TMPDIR = '';
+assert.strictEqual(os.tmpdir(), '/tmp');
+process.env.TMP = '';
+assert.strictEqual(os.tmpdir(), '/temp');
+process.env.TEMP = '';
+assert.strictEqual(os.tmpdir(), '/tmp');
+process.env.TMPDIR = '/tmpdir/';
+assert.strictEqual(os.tmpdir(), '/tmpdir');
+process.env.TMPDIR = '/tmpdir\\';
+assert.strictEqual(os.tmpdir(), '/tmpdir\\');
+process.env.TMPDIR = '/';
+assert.strictEqual(os.tmpdir(), '/');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

Implements the Node.js `os` API: https://nodejs.org/dist/latest-v12.x/docs/api/os.html#os_os_tmpdir

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
